### PR TITLE
Require username for deluser.sh

### DIFF
--- a/py/deluser.sh
+++ b/py/deluser.sh
@@ -3,6 +3,8 @@
 # Quickly delete all traces of a user from the database and filesystem
 # usage: ./deluser.sh username
 
+[ $# -eq 0 ] && { echo "Usage: $0 username"; exit 1; }
+
 USER=$1
 USERID=`sqlite3 ../database.db "select id from users where username = '${USER}'"`
 for table in albums comments images posts; do


### PR DESCRIPTION
Bad things happen if you accidentally execute deluser.sh with out supplying a username.
